### PR TITLE
Version Tolk git submodule and integrate with main crate build process.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/tolk"]
+	path = vendor/tolk
+	url = https://github.com/dkager/tolk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ version = "0.1.0"
 
 [dependencies]
 libc = "0.2.20"
+
+[build-dependencies]
+cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/darbaga/tolk-sys"
 readme = "README.md"
 categories = ["external-ffi-bindings"]
 license = "MIT"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 libc = "0.2.20"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,30 @@
-fn main() {
+use std::env;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+fn main() -> io::Result<()> {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let manifest = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let target = env::var("TARGET").unwrap();
+    let libs = if target.contains("64") {
+        format!("{}/vendor/tolk/libs/x64", manifest)
+    } else {
+        format!("{}/vendor/tolk/libs/686", manifest)
+    };
+    let mut target: PathBuf = out_dir.into();
+    target.pop();
+    target.pop();
+    target.pop();
+    let target = target.into_os_string().into_string().unwrap();
+    for entry in fs::read_dir(libs)? {
+        let path = entry.unwrap().path();
+        let file_name = path.file_name().unwrap().to_os_string().into_string().unwrap();
+        let out = format!("{}/{}", &target, &file_name);
+        fs::copy(&path, out)?;
+        let out = format!("{}/examples/{}", &target, &file_name);
+        fs::copy(&path, out)?;
+    }
     let root = "vendor/tolk";
     cc::Build::new()
         .cpp(true)
@@ -17,4 +43,5 @@ fn main() {
         .file(format!("{}/src/zt.c", root))
         .compile("tolk");
     println!("cargo:rustc-flags=-l User32 -l Ole32 -l OleAut32");
+    Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+fn main() {
+    let root = "vendor/tolk";
+    cc::Build::new()
+        .cpp(true)
+        .define("_EXPORTING", "")
+        .define("UNICODE", "")
+        .file(format!("{}/src/Tolk.cpp", root))
+        .file(format!("{}/src/ScreenReaderDriverJAWS.cpp", root))
+        .file(format!("{}/src/ScreenReaderDriverNVDA.cpp", root))
+        .file(format!("{}/src/ScreenReaderDriverSA.cpp", root))
+        .file(format!("{}/src/ScreenReaderDriverSNova.cpp", root))
+        .file(format!("{}/src/ScreenReaderDriverWE.cpp", root))
+        .file(format!("{}/src/ScreenReaderDriverZT.cpp", root))
+        .file(format!("{}/src/ScreenReaderDriverSAPI.cpp", root))
+        .file(format!("{}/src/fsapi.c", root))
+        .file(format!("{}/src/wineyes.c", root))
+        .file(format!("{}/src/zt.c", root))
+        .compile("tolk");
+    println!("cargo:rustc-flags=-l User32 -l Ole32 -l OleAut32");
+}


### PR DESCRIPTION
This PR does the following:
 * Builds Tolk sources as part of tolk-sys' build process.
 * Statically links the built Tolk library.
 * Places the DLLs for 32-bit or 64-bit dependencies alongside the dependent executable/library.
 * Bumps the version of this crate.

I have another PR, which I'll submit later today or tomorrow, that adds an example to the main tolk crate. With these changes merged, it should be possible to build crates depending on tolk with no additional work on the user's end, save for ensuring that the screen reader API DLLs are either copied from target/{debug,release} or from the Tolk distribution itself.

I'd like to pull this version of tolk-sys directly from crates.io and integrate it into a new version of the main tolk crate. So if you have any feedback on this PR, I'd like to work that out before submitting the secondary PR to bump the main crate version, add the example, and update the README.

Thanks.